### PR TITLE
Package: try

### DIFF
--- a/config.org
+++ b/config.org
@@ -106,10 +106,16 @@ As a newbie, it is difficult to remember all the keybindings. And I do not think
 
 We just told Emacs use-package to make sure that which-key is installed (=:ensure t=), if it is not already installed. Also, we told Emacs that once the package is installed and loaded, activate the =which-key-mode=.
 
+*** try
+[[https://github.com/larstvei/Try][try]] is a package to try out packages without installing them. The packages persist for the current Emacs session, and you can always install them if you like.
+#+BEGIN_SRC emacs-lisp
+(use-package try
+  :ensure t)
+#+END_SRC
+
 *** treemacs
 *** vc-gutter
 *** multiple-cursors
 *** completion: helm/ivy
 *** code completion
 Go straight to lsp? Is there value in having company?
-


### PR DESCRIPTION
Added config for `try`

I saw that there are different indentations in sections? In some source blocks there are 0/2/4 spaces. I like adding newlines before headlines and starting the content right after that, but that may not be the case with everybody.

It would be nice to have a explicit convention specified for contributors :smile: 